### PR TITLE
Starting eisen engine with supervisord

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.configure(2) do |config|
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.network "forwarded_port", guest: 5000, host: 5000
+  config.vm.network "forwarded_port", guest: 9001, host: 9001
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -70,7 +71,7 @@ Vagrant.configure(2) do |config|
     sudo apt-get update
 
     echo "installing needed packages"
-    sudo apt-get install -y python-pip python-crypto python-dev rabbitmq-server sshpass python-mysqldb
+    sudo apt-get install -y python-pip python-crypto python-dev rabbitmq-server sshpass python-mysqldb supervisor
     sudo pip install -r /vagrant/requirements.txt
 
     echo "adding localhost to /etc/ansible/hosts"
@@ -85,9 +86,9 @@ Vagrant.configure(2) do |config|
     sudo touch /root/.ssh/config
     sudo echo -e "Host *\n StrictHostKeyChecking no" > /root/.ssh/config
 
-    echo "Starting celeryworker"
-    chmod +x /vagrant/celeryworker.sh
-    # looks like bash is needed ...
-    C_FORCE_ROOT="true" nohup bash /vagrant/celeryworker.sh &
+    echo "setting supervisor port localhost:9001"
+    sudo echo -e "[inet_http_server]\nport=9001" >> /etc/supervisor/supervisord.conf
+    ln -s /vagrant/vagrant/celeryd.conf /etc/supervisor/conf.d/celeryd.conf
+    ln -s /vagrant/vagrant/engine.conf /etc/supervisor/conf.d/engine.conf
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,7 @@ Vagrant.configure(2) do |config|
     echo "adding StrictHostKeyChecking no to .ssh/config"
     echo -e "Host *\n StrictHostKeyChecking no" > /home/vagrant/.ssh/config
     chown vagrant:vagrant /home/vagrant/.ssh/config
+    mkdir /root/.ssh/
     sudo touch /root/.ssh/config
     sudo echo -e "Host *\n StrictHostKeyChecking no" > /root/.ssh/config
 
@@ -90,5 +91,9 @@ Vagrant.configure(2) do |config|
     sudo echo -e "[inet_http_server]\nport=9001" >> /etc/supervisor/supervisord.conf
     ln -s /vagrant/vagrant/celeryd.conf /etc/supervisor/conf.d/celeryd.conf
     ln -s /vagrant/vagrant/engine.conf /etc/supervisor/conf.d/engine.conf
+
+    echo "restart supervisor"
+    service supervisor stop
+    service supervisor start
   SHELL
 end

--- a/vagrant/celeryd.conf
+++ b/vagrant/celeryd.conf
@@ -1,0 +1,30 @@
+; ==================================
+;  celery worker supervisor example
+; ==================================
+
+[program:celery]
+command=celery worker -A bin.api.celery_work --loglevel=INFO
+
+directory=/vagrant
+user=vagrant
+group=vagrant
+environment=HOME="/home/vagrant"
+numprocs=1
+stdout_logfile=/var/log/celery_worker.log
+stderr_logfile=/var/log/celery_worker.log
+autostart=true
+autorestart=true
+startsecs=10
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
+
+; When resorting to send SIGKILL to the program to terminate it
+; send SIGKILL to its whole process group instead,
+; taking care of its children as well.
+killasgroup=true
+
+; Set Celery priority higher than default (999)
+; so, if rabbitmq is supervised, it will start first.
+priority=1000

--- a/vagrant/engine.conf
+++ b/vagrant/engine.conf
@@ -1,0 +1,24 @@
+; ==================================
+;  Eisen engine supervisor example
+; ==================================
+
+[program:engine]
+command=python /vagrant/bin/api.py
+
+directory=/vagrant
+user=vagrant
+numprocs=1
+stdout_logfile=/var/log/engine.log
+stderr_logfile=/var/log/engine.log
+autostart=true
+autorestart=true
+startsecs=10
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
+
+; When resorting to send SIGKILL to the program to terminate it
+; send SIGKILL to its whole process group instead,
+; taking care of its children as well.
+killasgroup=true


### PR DESCRIPTION
Because we want to better manage the eisen engine we are using supervisor for starting it, instead of calling the script from vagrantfile,
this give the possibility to restart the process from web interface and restart the process automatically if they die.